### PR TITLE
PvP Balance Patch #6.1

### DIFF
--- a/de-DE/de-DE-stringtablex.xml
+++ b/de-DE/de-DE-stringtablex.xml
@@ -16625,6 +16625,8 @@
 		<string _locid="110039">Königliche landwirtschaft</string>
 		<string _locid="110040">Entwickelt die Kultur zum Silber-Zeitalter weiter und verbessert &lt;color=0.32 0.65 1.0&gt;Dorfzentrum&lt;/color&gt;.*&lt;color=0.0 1.0 0.0&gt;Weiterentwicklung zum Silber-Zeitalter&lt;/color&gt;*&lt;color=0.0 1.0 0.0&gt;Lebenspunkte +33%&lt;/color&gt;*&lt;color=0.0 1.0 0.0&gt;Schaden +33%&lt;/color&gt;*&lt;color=0.0 1.0 0.0&gt;Errichtungsgrenze +1&lt;/color&gt;*&lt;color=0.0 1.0 0.0&gt;Wachturm Extraschaden +25% gegen &lt;/color&gt;&lt;color=0.32 0.65 1.0&gt;Fernkampf&lt;/color&gt;-Einheiten*&lt;color=0.0 1.0 0.0&gt;</string>
 		<string _locid="110041">Verbessert &lt;color=0.32 0.65 1.0&gt;Plünderer&lt;/color&gt;.*&lt;color=0.0 1.0 0.0&gt;Extraschaden +50% gegen &lt;/color&gt;&lt;color=0.32 0.65 1.0&gt;Dorfbewohner&lt;/color&gt;*&lt;color=0.0 1.0 0.0&gt;Bietet Verlangsamungsimmunität 75% &lt;/color&gt;</string>
+		<string _locid="110042">Erhöht Fassungsvermögen von &lt;color=0.32 0.65 1.0&gt;Gold Mine&lt;/color&gt;.*&lt;color=0.0 1.0 0.0&gt;Villagerkapazität +5&lt;/color&gt;</string>		
+		<string _locid="110043">Goldrausch</string>			
 		<!-- Celeste Chat Channel -->
 		<string _locid="160121">PVP</string>
 		<string _locid="160122">DE</string>

--- a/de-DE/de-DE-stringtablex.xml
+++ b/de-DE/de-DE-stringtablex.xml
@@ -16626,7 +16626,8 @@
 		<string _locid="110040">Entwickelt die Kultur zum Silber-Zeitalter weiter und verbessert &lt;color=0.32 0.65 1.0&gt;Dorfzentrum&lt;/color&gt;.*&lt;color=0.0 1.0 0.0&gt;Weiterentwicklung zum Silber-Zeitalter&lt;/color&gt;*&lt;color=0.0 1.0 0.0&gt;Lebenspunkte +33%&lt;/color&gt;*&lt;color=0.0 1.0 0.0&gt;Schaden +33%&lt;/color&gt;*&lt;color=0.0 1.0 0.0&gt;Errichtungsgrenze +1&lt;/color&gt;*&lt;color=0.0 1.0 0.0&gt;Wachturm Extraschaden +25% gegen &lt;/color&gt;&lt;color=0.32 0.65 1.0&gt;Fernkampf&lt;/color&gt;-Einheiten*&lt;color=0.0 1.0 0.0&gt;</string>
 		<string _locid="110041">Verbessert &lt;color=0.32 0.65 1.0&gt;Plünderer&lt;/color&gt;.*&lt;color=0.0 1.0 0.0&gt;Extraschaden +50% gegen &lt;/color&gt;&lt;color=0.32 0.65 1.0&gt;Dorfbewohner&lt;/color&gt;*&lt;color=0.0 1.0 0.0&gt;Bietet Verlangsamungsimmunität 75% &lt;/color&gt;</string>
 		<string _locid="110042">Erhöht Fassungsvermögen von &lt;color=0.32 0.65 1.0&gt;Gold Mine&lt;/color&gt;.*&lt;color=0.0 1.0 0.0&gt;Villagerkapazität +5&lt;/color&gt;</string>		
-		<string _locid="110043">Goldrausch</string>			
+		<string _locid="110043">Goldfieber</string>	
+		<string _locid="110044">Verbessert &lt;color=0.32 0.65 1.0&gt;Elefanten-Bogenschützen&lt;/color&gt;.*&lt;color=0.0 1.0 0.0&gt;Bevölkerungszahl -1&lt;/color&gt;*&lt;color=0.0 1.0 0.0&gt;Nahkampf-Kavalrierüstung +50%&lt;/color&gt;</string>		
 		<!-- Celeste Chat Channel -->
 		<string _locid="160121">PVP</string>
 		<string _locid="160122">DE</string>

--- a/en-US/QuestStringTable.xml
+++ b/en-US/QuestStringTable.xml
@@ -3412,8 +3412,8 @@
 		<!-- ATHENS CELESTE PDLC SPECIAL EDITION GREEK - La revuelta Griega -->
 		<string _locid="20015">Celeste Special Content: The Greek Revolt</string>
 		<string _locid="20016">New free content available. Travel to Athens and discover new adventures</string>
-		<string _locid="20017">Welcome to Athens, contemplate the splendor of our city. \n \ nSo, if you're still here, maybe I need your help. What do you say?</string>
-		<string _locid="20018">Welcome to Athens, contemplate the splendor of our city. \n \ nSo, if you're still here, maybe I need your help. What do you say?</string>
+		<string _locid="20017">Welcome to Athens, contemplate the splendor of our city. \n \nSo, if you're still here, maybe I need your help. What do you say?</string>
+		<string _locid="20018">Welcome to Athens, contemplate the splendor of our city. \n \nSo, if you're still here, maybe I need your help. What do you say?</string>
 		<string _locid="20019">Speak to the Leader Hoplite in Athens</string>
 		<string _locid="20020">Travel to Athens and talk to Hoplite Leader</string>
 		<!-- ATHENS START INCURSION -->
@@ -3590,5 +3590,18 @@
 		<string _locid="20157">Defeat yourself in Legendary 2vs2 AI: Skirmish Champion Mode</string>
 		<string _locid="20158">Defeat yourself</string>
 		<string _locid="20159">Defeat yourself Coop</string>
+		
+		<!-- Wonder Defense -->
+		<string _locid="20160">Wonder Defense</string>
+		<string _locid="20161"></string>
+		<string _locid="20162"></string>
+		<string _locid="20163"></string>
+		<string _locid="20164"></string>
+		<string _locid="20165"></string>
+		<string _locid="20166"></string>
+		<string _locid="20167"></string>
+		<string _locid="20168"></string>
+		<string _locid="20169">Good Guy</string>
+		<string _locid="20170">Bad Guy</string>
 	</language>
 </stringtable>

--- a/en-US/Stringtablex.xml
+++ b/en-US/Stringtablex.xml
@@ -16625,6 +16625,9 @@
 		<string _locid="110039">Royal Agriculture</string>
 		<string _locid="110040">Advances civilization to Silver Age and improves &lt;color=0.32 0.65 1.0&gt;Town Center&lt;/color&gt;.*&lt;color=0.0 1.0 0.0&gt;Advance to Silver Age&lt;/color&gt;*&lt;color=0.0 1.0 0.0&gt;+33% Health&lt;/color&gt;*&lt;color=0.0 1.0 0.0&gt;+33% Damage&lt;/color&gt;*&lt;color=0.0 1.0 0.0&gt;+1 Build Limit&lt;/color&gt;*&lt;color=0.0 1.0 0.0&gt;+25%&lt;/color&gt; &lt;color=0.32 0.65 1.0&gt;Guard Tower&lt;/color&gt; &lt;color=0.0 1.0 0.0&gt;Bonus Damage vs.&lt;/color&gt; &lt;/color&gt;&lt;color=0.32 0.65 1.0&gt;Ranged&lt;/color&gt;</string>
 		<string _locid="110041">Improves &lt;color=0.32 0.65 1.0&gt;Raider&lt;/color&gt;.*&lt;color=0.0 1.0 0.0&gt;+50% Bonus Damage vs. &lt;/color&gt;&lt;color=0.32 0.65 1.0&gt;Villagers&lt;/color&gt;*&lt;color=0.0 1.0 0.0&gt;+75% Snare Resistance &lt;/color&gt;</string>
+		<string _locid="110042">Increases capacity of &lt;color=0.32 0.65 1.0&gt;Gold Mine&lt;/color&gt;.*&lt;color=0.0 1.0 0.0&gt;+5 Villager Capacity&lt;/color&gt;</string>		
+		<string _locid="110043">Gold Rush</string>	
+		<string _locid="110044">Improves &lt;color=0.32 0.65 1.0&gt;Elephant Archer&lt;/color&gt;.*&lt;color=0.0 1.0 0.0&gt;-1 Population Count&lt;/color&gt;*&lt;color=0.0 1.0 0.0&gt;+50% Melee-Cavalry Armor&lt;/color&gt; </string>		
 		<!-- Celeste Chat Channel -->
 		<string _locid="160121">PVP</string>
 		<string _locid="160122">DE</string>

--- a/es-ES/es-ES-stringtablex.xml
+++ b/es-ES/es-ES-stringtablex.xml
@@ -16625,6 +16625,8 @@
 		<string _locid="110039">Agricultura real</string>
 		<string _locid="110040">Hace avanzar la civilización a la Edad de Plata y mejora el &lt;color=0.32 0.65 1.0&gt;centro urbano&lt;/color&gt;.*&lt;color=0.0 1.0 0.0&gt;Avanza a Edad de Plata&lt;/color&gt;*&lt;color=0.0 1.0 0.0&gt;+33% de salud&lt;/color&gt;*&lt;color=0.0 1.0 0.0&gt;+33% de daño&lt;/color&gt;*&lt;color=0.0 1.0 0.0&gt;+1 límite de construcción&lt;/color&gt;*&lt;color=0.0 1.0 0.0&gt;+25% Torre de vigilancia de daño adicional contra &lt;/color&gt;&lt;color=0.32 0.65 1.0&gt;unidades a distancia&lt;/color&gt;*&lt;color=0.0 1.0 0.0&gt;</string>
 		<string _locid="110041">Mejora el &lt;color=0.32 0.65 1.0&gt;asaltante&lt;/color&gt;.*&lt;color=0.0 1.0 0.0&gt;+50% de daño adicional contra &lt;/color&gt;&lt;color=0.32 0.65 1.0&gt;aldeanos&lt;/color&gt;*&lt;color=0.0 1.0 0.0&gt;Otorga 75% contra ralentización&lt;/color&gt;</string>
+		<string _locid="110042">Aumenta la capacidad de los &lt;color=0.32 0.65 1.0&gt;Gold Mine&lt;/color&gt;.*&lt;color=0.0 1.0 0.0&gt;+5 de capacidad de villageros&lt;/color&gt;</string>		
+		<string _locid="110043">Fiebre del Oro</string>	
 		<!-- Celeste Chat Channel -->
 		<string _locid="160121">PVP</string>
 		<string _locid="160122">DE</string>

--- a/es-ES/es-ES-stringtablex.xml
+++ b/es-ES/es-ES-stringtablex.xml
@@ -16627,6 +16627,7 @@
 		<string _locid="110041">Mejora el &lt;color=0.32 0.65 1.0&gt;asaltante&lt;/color&gt;.*&lt;color=0.0 1.0 0.0&gt;+50% de daño adicional contra &lt;/color&gt;&lt;color=0.32 0.65 1.0&gt;aldeanos&lt;/color&gt;*&lt;color=0.0 1.0 0.0&gt;Otorga 75% contra ralentización&lt;/color&gt;</string>
 		<string _locid="110042">Aumenta la capacidad de los &lt;color=0.32 0.65 1.0&gt;Gold Mine&lt;/color&gt;.*&lt;color=0.0 1.0 0.0&gt;+5 de capacidad de villageros&lt;/color&gt;</string>		
 		<string _locid="110043">Fiebre del Oro</string>	
+		<string _locid="110044">Mejora el &lt;color=0.32 0.65 1.0&gt;arquero en elefante&lt;/color&gt;.*&lt;color=0.0 1.0 0.0&gt;-1 de población&lt;/color&gt;*&lt;color=0.0 1.0 0.0&gt;+50% armadura contra infantería cuerpo a cuerpo&lt;/color&gt;</string>		
 		<!-- Celeste Chat Channel -->
 		<string _locid="160121">PVP</string>
 		<string _locid="160122">DE</string>

--- a/fr-FR/fr-FR-stringtablex.xml
+++ b/fr-FR/fr-FR-stringtablex.xml
@@ -16626,7 +16626,8 @@
 		<string _locid="110040">Fait avancer votre civilisation à l&apos;Âge d&apos;Argent et améliore les &lt;color=0.32 0.65 1.0&gt;forums&lt;/color&gt;.*&lt;color=0.0 1.0 0.0&gt;Avancer à l&apos;Âge d&apos;Argent&lt;/color&gt;*&lt;color=0.0 1.0 0.0&gt;Santé +33%&lt;/color&gt;*&lt;color=0.0 1.0 0.0&gt;Dégâts +33%&lt;/color&gt;*&lt;color=0.0 1.0 0.0&gt;Limite de construction +1&lt;/color&gt;*&lt;color=0.0 1.0 0.0&gt;+25% Tour de garde de bonus aux dégâts contre les &lt;/color&gt;&lt;color=0.32 0.65 1.0&gt;attaques à distances&lt;/color&gt;</string>
 		<string _locid="110041">Améliore les&lt;color=0.32 0.65 1.0&gt;pillards&lt;/color&gt;.*&lt;color=0.0 1.0 0.0&gt;+50 % de bonus aux dégâts contre les &lt;/color&gt;&lt;color=0.32 0.65 1.0&gt;villageois&lt;/color&gt;*&lt;color=0.0 1.0 0.0&gt;Octroie 75% contre les pièges&lt;/color&gt;</string>
 		<string _locid="110042">Augmente la capacité des &lt;color=0.32 0.65 1.0&gt;Gold Mine&lt;/color&gt;.*&lt;color=0.0 1.0 0.0&gt;Capacité de villagers +8&lt;/color&gt;</string>		
-		<string _locid="110043">La ruée vers l'or</string>			
+		<string _locid="110043">La ruée vers l'or</string>		
+		<string _locid="110044">Améliore &lt;color=0.32 0.65 1.0&gt;Archer sur éléphant&lt;/color&gt;.*&lt;color=0.0 1.0 0.0&gt;-1 compte démographique&lt;/color&gt;*&lt;color=0.0 1.0 0.0&gt;Armure d&apos;cavalerie en mêlée +50%&lt;/color&gt;</string>		
 		<!-- Celeste Chat Channel -->
 		<string _locid="160121">PVP</string>
 		<string _locid="160122">DE</string>

--- a/fr-FR/fr-FR-stringtablex.xml
+++ b/fr-FR/fr-FR-stringtablex.xml
@@ -16625,6 +16625,8 @@
 		<string _locid="110039">Agriculture royale</string>
 		<string _locid="110040">Fait avancer votre civilisation à l&apos;Âge d&apos;Argent et améliore les &lt;color=0.32 0.65 1.0&gt;forums&lt;/color&gt;.*&lt;color=0.0 1.0 0.0&gt;Avancer à l&apos;Âge d&apos;Argent&lt;/color&gt;*&lt;color=0.0 1.0 0.0&gt;Santé +33%&lt;/color&gt;*&lt;color=0.0 1.0 0.0&gt;Dégâts +33%&lt;/color&gt;*&lt;color=0.0 1.0 0.0&gt;Limite de construction +1&lt;/color&gt;*&lt;color=0.0 1.0 0.0&gt;+25% Tour de garde de bonus aux dégâts contre les &lt;/color&gt;&lt;color=0.32 0.65 1.0&gt;attaques à distances&lt;/color&gt;</string>
 		<string _locid="110041">Améliore les&lt;color=0.32 0.65 1.0&gt;pillards&lt;/color&gt;.*&lt;color=0.0 1.0 0.0&gt;+50 % de bonus aux dégâts contre les &lt;/color&gt;&lt;color=0.32 0.65 1.0&gt;villageois&lt;/color&gt;*&lt;color=0.0 1.0 0.0&gt;Octroie 75% contre les pièges&lt;/color&gt;</string>
+		<string _locid="110042">Augmente la capacité des &lt;color=0.32 0.65 1.0&gt;Gold Mine&lt;/color&gt;.*&lt;color=0.0 1.0 0.0&gt;Capacité de villagers +8&lt;/color&gt;</string>		
+		<string _locid="110043">La ruée vers l'or</string>			
 		<!-- Celeste Chat Channel -->
 		<string _locid="160121">PVP</string>
 		<string _locid="160122">DE</string>

--- a/it-IT/it-IT-stringtablex.xml
+++ b/it-IT/it-IT-stringtablex.xml
@@ -16134,6 +16134,8 @@
 		<string _locid="110039">Royal Agriculture</string>
 		<string _locid="110040">Advances civilization to Silver Age and improves &lt;color=0.32 0.65 1.0&gt;Town Center&lt;/color&gt;.*&lt;color=0.0 1.0 0.0&gt;Advance to Silver Age&lt;/color&gt;*&lt;color=0.0 1.0 0.0&gt;+33% Health&lt;/color&gt;*&lt;color=0.0 1.0 0.0&gt;+33% Damage&lt;/color&gt;*&lt;color=0.0 1.0 0.0&gt;+1 Build Limit&lt;/color&gt;*&lt;color=0.0 1.0 0.0&gt;+25%&lt;/color&gt; &lt;color=0.32 0.65 1.0&gt;Guard Tower&lt;/color&gt; &lt;color=0.0 1.0 0.0&gt;Bonus Damage vs.&lt;/color&gt; &lt;/color&gt;&lt;color=0.32 0.65 1.0&gt;Ranged&lt;/color&gt;</string>
 		<string _locid="110041">Improves &lt;color=0.32 0.65 1.0&gt;Raider&lt;/color&gt;.*&lt;color=0.0 1.0 0.0&gt;+50% Bonus Damage vs. &lt;/color&gt;&lt;color=0.32 0.65 1.0&gt;Villagers&lt;/color&gt;*&lt;color=0.0 1.0 0.0&gt;+75% Snare Resistance &lt;/color&gt;</string>
+		<string _locid="110042">Increases capacity of &lt;color=0.32 0.65 1.0&gt;Gold Mine&lt;/color&gt;.*&lt;color=0.0 1.0 0.0&gt;+5 Villager Capacity&lt;/color&gt;</string>	
+		<string _locid="110043">Gold Rush</string>			
 		<!-- Celeste Chat Channel -->
 		<string _locid="160121">PVP</string>
 		<string _locid="160122">DE</string>

--- a/it-IT/it-IT-stringtablex.xml
+++ b/it-IT/it-IT-stringtablex.xml
@@ -16135,7 +16135,8 @@
 		<string _locid="110040">Advances civilization to Silver Age and improves &lt;color=0.32 0.65 1.0&gt;Town Center&lt;/color&gt;.*&lt;color=0.0 1.0 0.0&gt;Advance to Silver Age&lt;/color&gt;*&lt;color=0.0 1.0 0.0&gt;+33% Health&lt;/color&gt;*&lt;color=0.0 1.0 0.0&gt;+33% Damage&lt;/color&gt;*&lt;color=0.0 1.0 0.0&gt;+1 Build Limit&lt;/color&gt;*&lt;color=0.0 1.0 0.0&gt;+25%&lt;/color&gt; &lt;color=0.32 0.65 1.0&gt;Guard Tower&lt;/color&gt; &lt;color=0.0 1.0 0.0&gt;Bonus Damage vs.&lt;/color&gt; &lt;/color&gt;&lt;color=0.32 0.65 1.0&gt;Ranged&lt;/color&gt;</string>
 		<string _locid="110041">Improves &lt;color=0.32 0.65 1.0&gt;Raider&lt;/color&gt;.*&lt;color=0.0 1.0 0.0&gt;+50% Bonus Damage vs. &lt;/color&gt;&lt;color=0.32 0.65 1.0&gt;Villagers&lt;/color&gt;*&lt;color=0.0 1.0 0.0&gt;+75% Snare Resistance &lt;/color&gt;</string>
 		<string _locid="110042">Increases capacity of &lt;color=0.32 0.65 1.0&gt;Gold Mine&lt;/color&gt;.*&lt;color=0.0 1.0 0.0&gt;+5 Villager Capacity&lt;/color&gt;</string>	
-		<string _locid="110043">Gold Rush</string>			
+		<string _locid="110043">Gold Rush</string>	
+		<string _locid="110044">Improves &lt;color=0.32 0.65 1.0&gt;Elephant Archer&lt;/color&gt;.*&lt;color=0.0 1.0 0.0&gt;-1 Population Count&lt;/color&gt;*&lt;color=0.0 1.0 0.0&gt;+50% Melee-Cavalry Armor&lt;/color&gt; </string>				
 		<!-- Celeste Chat Channel -->
 		<string _locid="160121">PVP</string>
 		<string _locid="160122">DE</string>

--- a/zh-CHT/zh-CHT-stringtablex.xml
+++ b/zh-CHT/zh-CHT-stringtablex.xml
@@ -16136,6 +16136,7 @@
 		<string _locid="110041">Improves &lt;color=0.32 0.65 1.0&gt;Raider&lt;/color&gt;.*&lt;color=0.0 1.0 0.0&gt;+50% Bonus Damage vs. &lt;/color&gt;&lt;color=0.32 0.65 1.0&gt;Villagers&lt;/color&gt;*&lt;color=0.0 1.0 0.0&gt;+75% Snare Resistance &lt;/color&gt;</string>
 		<string _locid="110042">Increases capacity of &lt;color=0.32 0.65 1.0&gt;Gold Mine&lt;/color&gt;.*&lt;color=0.0 1.0 0.0&gt;+5 Villager Capacity&lt;/color&gt;</string>	
 		<string _locid="110043">Gold Rush</string>	
+		<string _locid="110044">Improves &lt;color=0.32 0.65 1.0&gt;Elephant Archer&lt;/color&gt;.*&lt;color=0.0 1.0 0.0&gt;-1 Population Count&lt;/color&gt;*&lt;color=0.0 1.0 0.0&gt;+50% Melee-Cavalry Armor&lt;/color&gt; </string>				
 		<!-- Celeste Chat Channel -->
 		<string _locid="160121">PVP</string>
 		<string _locid="160122">DE</string>

--- a/zh-CHT/zh-CHT-stringtablex.xml
+++ b/zh-CHT/zh-CHT-stringtablex.xml
@@ -16134,6 +16134,8 @@
 		<string _locid="110039">Royal Agriculture</string>
 		<string _locid="110040">Advances civilization to Silver Age and improves &lt;color=0.32 0.65 1.0&gt;Town Center&lt;/color&gt;.*&lt;color=0.0 1.0 0.0&gt;Advance to Silver Age&lt;/color&gt;*&lt;color=0.0 1.0 0.0&gt;+33% Health&lt;/color&gt;*&lt;color=0.0 1.0 0.0&gt;+33% Damage&lt;/color&gt;*&lt;color=0.0 1.0 0.0&gt;+1 Build Limit&lt;/color&gt;*&lt;color=0.0 1.0 0.0&gt;+25%&lt;/color&gt; &lt;color=0.32 0.65 1.0&gt;Guard Tower&lt;/color&gt; &lt;color=0.0 1.0 0.0&gt;Bonus Damage vs.&lt;/color&gt; &lt;/color&gt;&lt;color=0.32 0.65 1.0&gt;Ranged&lt;/color&gt;</string>
 		<string _locid="110041">Improves &lt;color=0.32 0.65 1.0&gt;Raider&lt;/color&gt;.*&lt;color=0.0 1.0 0.0&gt;+50% Bonus Damage vs. &lt;/color&gt;&lt;color=0.32 0.65 1.0&gt;Villagers&lt;/color&gt;*&lt;color=0.0 1.0 0.0&gt;+75% Snare Resistance &lt;/color&gt;</string>
+		<string _locid="110042">Increases capacity of &lt;color=0.32 0.65 1.0&gt;Gold Mine&lt;/color&gt;.*&lt;color=0.0 1.0 0.0&gt;+5 Villager Capacity&lt;/color&gt;</string>	
+		<string _locid="110043">Gold Rush</string>	
 		<!-- Celeste Chat Channel -->
 		<string _locid="160121">PVP</string>
 		<string _locid="160122">DE</string>


### PR DESCRIPTION
Greeks:

Greek Sarissophoroi: HP reduced to 400, from 420.

--------------------
Egyptians:

Egyptian Elephant Archer: Hitpoints increased to 770, from 700. Champion Upgrade now also gives +50% Melee-Cavalry Armor.

--------------------
Persians:


--------------------
Celts:

Call to Arms: This tech has been replaced with Gold Rush: Age3 upgrade, 150w, increases Gold Mine capacity by 5

--------------------
Babylonians:


--------------------
Norse:


--------------------
General Changes:

Single-Target Heal Priests' heal rate increased to 40, from 25