### PR TITLE
Balance Patch #6.2

### DIFF
--- a/de-DE/de-DE-stringtablex.xml
+++ b/de-DE/de-DE-stringtablex.xml
@@ -16627,8 +16627,11 @@
 		<string _locid="110041">Verbessert &lt;color=0.32 0.65 1.0&gt;Plünderer&lt;/color&gt;.*&lt;color=0.0 1.0 0.0&gt;Extraschaden +50% gegen &lt;/color&gt;&lt;color=0.32 0.65 1.0&gt;Dorfbewohner&lt;/color&gt;*&lt;color=0.0 1.0 0.0&gt;Bietet Verlangsamungsimmunität 75% &lt;/color&gt;</string>
 		<string _locid="110042">Erhöht Fassungsvermögen von &lt;color=0.32 0.65 1.0&gt;Gold Mine&lt;/color&gt;.*&lt;color=0.0 1.0 0.0&gt;Villagerkapazität +5&lt;/color&gt;</string>		
 		<string _locid="110043">Goldfieber</string>	
-		<string _locid="110044">Verbessert &lt;color=0.32 0.65 1.0&gt;Elefanten-Bogenschützen&lt;/color&gt;.*&lt;color=0.0 1.0 0.0&gt;Bevölkerungszahl -1&lt;/color&gt;*&lt;color=0.0 1.0 0.0&gt;Nahkampf-Kavalrierüstung +50%&lt;/color&gt;</string>		
-		<!-- Celeste Chat Channel -->
+		<string _locid="110044">Verbessert &lt;color=0.32 0.65 1.0&gt;Elefanten-Bogenschützen&lt;/color&gt;.*&lt;color=0.0 1.0 0.0&gt;Bevölkerungszahl -1&lt;/color&gt;*&lt;color=0.0 1.0 0.0&gt;Nahkampf-Kavalrierüstung +50%&lt;/color&gt;</string>
+		<string _locid="110045">Reduziert die Ausbildungsdauer von &lt;color=0.32 0.65 1.0&gt;Dorfbewohnern&lt;/color&gt;, ändert aber ihre Kosten in Gold.*&lt;color=0.0 1.0 0.0&gt;Ausbildungsdauer -33%&lt;/color&gt;*&lt;color=0.0 1.0 0.0&gt;Nahrungskosten -40&lt;/color&gt;*&lt;color=1.0 0.0 0.0&gt;Goldkosten +40&lt;/color&gt;*&lt;color=1.0 1.0 0.0&gt;Kann ein- und ausgeschaltet werden&lt;/color&gt;</string>
+		<string _locid="110046">Deaktiviere Lohnarbeit - Dorfbewohner werden um 33% schneller ausgebildet, müssen dann aber mit Gold bezahlt werden</string>		
+		<string _locid="110047">Verbessert &lt;color=0.32 0.65 1.0&gt;Berserker&lt;/color&gt;.*&lt;color=0.0 1.0 0.0&gt;Lebenspunktregen. pro Sekunde +2&lt;/color&gt;*&lt;color=0.0 1.0 0.0&gt;Bietet Sturmangriff&lt;/color&gt;*&lt;color=0.0 1.0 0.0&gt;Bietet Verlangsamungsimmunität&lt;/color&gt;</string>		
+				<!-- Celeste Chat Channel -->
 		<string _locid="160121">PVP</string>
 		<string _locid="160122">DE</string>
 		<string _locid="160123">ES</string>

--- a/en-US/Stringtablex.xml
+++ b/en-US/Stringtablex.xml
@@ -16628,6 +16628,9 @@
 		<string _locid="110042">Increases capacity of &lt;color=0.32 0.65 1.0&gt;Gold Mine&lt;/color&gt;.*&lt;color=0.0 1.0 0.0&gt;+5 Villager Capacity&lt;/color&gt;</string>		
 		<string _locid="110043">Gold Rush</string>	
 		<string _locid="110044">Improves &lt;color=0.32 0.65 1.0&gt;Elephant Archer&lt;/color&gt;.*&lt;color=0.0 1.0 0.0&gt;-1 Population Count&lt;/color&gt;*&lt;color=0.0 1.0 0.0&gt;+50% Melee-Cavalry Armor&lt;/color&gt; </string>		
+		<string _locid="110045">Reduces training time of &lt;color=0.32 0.65 1.0&gt;Villager&lt;/color&gt;, but changes their cost to Gold.*&lt;color=0.0 1.0 0.0&gt;-33% Training Time&lt;/color&gt;*&lt;color=0.0 1.0 0.0&gt;-40 Food Cost&lt;/color&gt;*&lt;color=1.0 0.0 0.0&gt;+40 Gold Cost&lt;/color&gt;*&lt;color=1.0 1.0 0.0&gt;Can Be Toggled On/Off&lt;/color&gt;</string>		
+		<string _locid="110046">Activate Paid Labor - Villagers train in 33% less time, but changes their cost to Gold</string>		
+		<string _locid="110047">Improves &lt;color=0.32 0.65 1.0&gt;Berserker&lt;/color&gt;.*&lt;color=0.0 1.0 0.0&gt;+2 Health Regen. Per Second&lt;/color&gt;*&lt;color=0.0 1.0 0.0&gt;Grants Charge&lt;/color&gt;*&lt;color=0.0 1.0 0.0&gt;Grants Snare Immunity&lt;/color&gt;</string>		
 		<!-- Celeste Chat Channel -->
 		<string _locid="160121">PVP</string>
 		<string _locid="160122">DE</string>

--- a/es-ES/es-ES-stringtablex.xml
+++ b/es-ES/es-ES-stringtablex.xml
@@ -16627,7 +16627,10 @@
 		<string _locid="110041">Mejora el &lt;color=0.32 0.65 1.0&gt;asaltante&lt;/color&gt;.*&lt;color=0.0 1.0 0.0&gt;+50% de daño adicional contra &lt;/color&gt;&lt;color=0.32 0.65 1.0&gt;aldeanos&lt;/color&gt;*&lt;color=0.0 1.0 0.0&gt;Otorga 75% contra ralentización&lt;/color&gt;</string>
 		<string _locid="110042">Aumenta la capacidad de los &lt;color=0.32 0.65 1.0&gt;Gold Mine&lt;/color&gt;.*&lt;color=0.0 1.0 0.0&gt;+5 de capacidad de villageros&lt;/color&gt;</string>		
 		<string _locid="110043">Fiebre del Oro</string>	
-		<string _locid="110044">Mejora el &lt;color=0.32 0.65 1.0&gt;arquero en elefante&lt;/color&gt;.*&lt;color=0.0 1.0 0.0&gt;-1 de población&lt;/color&gt;*&lt;color=0.0 1.0 0.0&gt;+50% armadura contra infantería cuerpo a cuerpo&lt;/color&gt;</string>		
+		<string _locid="110044">Mejora el &lt;color=0.32 0.65 1.0&gt;arquero en elefante&lt;/color&gt;.*&lt;color=0.0 1.0 0.0&gt;-1 de población&lt;/color&gt;*&lt;color=0.0 1.0 0.0&gt;+50% armadura contra infantería cuerpo a cuerpo&lt;/color&gt;</string>	
+		<string _locid="110045">Reduce el tiempo de formación de los &lt;color=0.32 0.65 1.0&gt;aldeanos&lt;/color&gt;, pero cambia su coste a oro.*&lt;color=0.0 1.0 0.0&gt;-33% de tiempo de formación&lt;/color&gt;*&lt;color=0.0 1.0 0.0&gt;-40 de coste de comida&lt;/color&gt;*&lt;color=1.0 0.0 0.0&gt;+40 de coste en oro&lt;/color&gt;*&lt;color=1.0 1.0 0.0&gt;Puede activarse y desactivarse&lt;/color&gt;</string>		
+		<string _locid="110046">Activar la mano de obra pagada: los aldeanos se forman en un 45% menos de tiempo pero cambia su coste a oro</string>		
+		<string _locid="110047">Mejora el &lt;color=0.32 0.65 1.0&gt;berserker&lt;/color&gt;.*&lt;color=0.0 1.0 0.0&gt;+2 de regeneración de salud por segundo&lt;/color&gt;*&lt;color=0.0 1.0 0.0&gt;Otorga carga&lt;/color&gt;*&lt;color=0.0 1.0 0.0&gt;Otorga inmunidad contra ralentización&lt;/color&gt;</string>		
 		<!-- Celeste Chat Channel -->
 		<string _locid="160121">PVP</string>
 		<string _locid="160122">DE</string>

--- a/fr-FR/fr-FR-stringtablex.xml
+++ b/fr-FR/fr-FR-stringtablex.xml
@@ -16627,7 +16627,10 @@
 		<string _locid="110041">Améliore les&lt;color=0.32 0.65 1.0&gt;pillards&lt;/color&gt;.*&lt;color=0.0 1.0 0.0&gt;+50 % de bonus aux dégâts contre les &lt;/color&gt;&lt;color=0.32 0.65 1.0&gt;villageois&lt;/color&gt;*&lt;color=0.0 1.0 0.0&gt;Octroie 75% contre les pièges&lt;/color&gt;</string>
 		<string _locid="110042">Augmente la capacité des &lt;color=0.32 0.65 1.0&gt;Gold Mine&lt;/color&gt;.*&lt;color=0.0 1.0 0.0&gt;Capacité de villagers +8&lt;/color&gt;</string>		
 		<string _locid="110043">La ruée vers l'or</string>		
-		<string _locid="110044">Améliore &lt;color=0.32 0.65 1.0&gt;Archer sur éléphant&lt;/color&gt;.*&lt;color=0.0 1.0 0.0&gt;-1 compte démographique&lt;/color&gt;*&lt;color=0.0 1.0 0.0&gt;Armure d&apos;cavalerie en mêlée +50%&lt;/color&gt;</string>		
+		<string _locid="110044">Améliore &lt;color=0.32 0.65 1.0&gt;Archer sur éléphant&lt;/color&gt;.*&lt;color=0.0 1.0 0.0&gt;-1 compte démographique&lt;/color&gt;*&lt;color=0.0 1.0 0.0&gt;Armure d&apos;cavalerie en mêlée +50%&lt;/color&gt;</string>	
+		<string _locid="110045">Réduit le temps de formation des &lt;color=0.32 0.65 1.0&gt;villageois&lt;/color&gt;, mais ils coûtent de l&apos;Or.*&lt;color=0.0 1.0 0.0&gt;-33 % période d&apos;entraînement&lt;/color&gt;*&lt;color=0.0 1.0 0.0&gt;-40 coût de la nourriture&lt;/color&gt;*&lt;color=1.0 0.0 0.0&gt;+40 coût de l&apos;Orlt;/color&gt;*&lt;color=1.0 1.0 0.0&gt;Peut être alterné d&apos;actif à inactif&lt;/color&gt;</string>		
+		<string _locid="110046">Activer Main d&apos;oeuvre payée - Les villageois sont formés en 45 % moins de temps, mais ils coûtent de l&apos;Or.</string>		
+		<string _locid="67579">Améliore les &lt;color=0.32 0.65 1.0&gt;Berserkers&lt;/color&gt;.*&lt;color=0.0 1.0 0.0&gt;Régén. santé par seconde +2&lt;/color&gt;*&lt;color=0.0 1.0 0.0&gt;Octroie Charge&lt;/color&gt;*&lt;color=0.0 1.0 0.0&gt;Octroie Immunité contre les pièges&lt;/color&gt;</string>		
 		<!-- Celeste Chat Channel -->
 		<string _locid="160121">PVP</string>
 		<string _locid="160122">DE</string>

--- a/it-IT/it-IT-stringtablex.xml
+++ b/it-IT/it-IT-stringtablex.xml
@@ -16137,6 +16137,9 @@
 		<string _locid="110042">Increases capacity of &lt;color=0.32 0.65 1.0&gt;Gold Mine&lt;/color&gt;.*&lt;color=0.0 1.0 0.0&gt;+5 Villager Capacity&lt;/color&gt;</string>	
 		<string _locid="110043">Gold Rush</string>	
 		<string _locid="110044">Improves &lt;color=0.32 0.65 1.0&gt;Elephant Archer&lt;/color&gt;.*&lt;color=0.0 1.0 0.0&gt;-1 Population Count&lt;/color&gt;*&lt;color=0.0 1.0 0.0&gt;+50% Melee-Cavalry Armor&lt;/color&gt; </string>				
+		<string _locid="110045">Reduces training time of &lt;color=0.32 0.65 1.0&gt;Villager&lt;/color&gt;, but changes their cost to Gold.*&lt;color=0.0 1.0 0.0&gt;-33% Training Time&lt;/color&gt;*&lt;color=0.0 1.0 0.0&gt;-40 Food Cost&lt;/color&gt;*&lt;color=1.0 0.0 0.0&gt;+40 Gold Cost&lt;/color&gt;*&lt;color=1.0 1.0 0.0&gt;Can Be Toggled On/Off&lt;/color&gt;</string>	
+		<string _locid="110046">Activate Paid Labor - Villagers train in 33% less time, but changes their cost to Gold</string>		
+		<string _locid="110047">Improves &lt;color=0.32 0.65 1.0&gt;Berserker&lt;/color&gt;.*&lt;color=0.0 1.0 0.0&gt;+2 Health Regen. Per Second&lt;/color&gt;*&lt;color=0.0 1.0 0.0&gt;Grants Charge&lt;/color&gt;*&lt;color=0.0 1.0 0.0&gt;Grants Snare Immunity&lt;/color&gt;</string>			
 		<!-- Celeste Chat Channel -->
 		<string _locid="160121">PVP</string>
 		<string _locid="160122">DE</string>

--- a/zh-CHT/zh-CHT-stringtablex.xml
+++ b/zh-CHT/zh-CHT-stringtablex.xml
@@ -16137,6 +16137,9 @@
 		<string _locid="110042">Increases capacity of &lt;color=0.32 0.65 1.0&gt;Gold Mine&lt;/color&gt;.*&lt;color=0.0 1.0 0.0&gt;+5 Villager Capacity&lt;/color&gt;</string>	
 		<string _locid="110043">Gold Rush</string>	
 		<string _locid="110044">Improves &lt;color=0.32 0.65 1.0&gt;Elephant Archer&lt;/color&gt;.*&lt;color=0.0 1.0 0.0&gt;-1 Population Count&lt;/color&gt;*&lt;color=0.0 1.0 0.0&gt;+50% Melee-Cavalry Armor&lt;/color&gt; </string>				
+		<string _locid="110045">Reduces training time of &lt;color=0.32 0.65 1.0&gt;Villager&lt;/color&gt;, but changes their cost to Gold.*&lt;color=0.0 1.0 0.0&gt;-33% Training Time&lt;/color&gt;*&lt;color=0.0 1.0 0.0&gt;-40 Food Cost&lt;/color&gt;*&lt;color=1.0 0.0 0.0&gt;+40 Gold Cost&lt;/color&gt;*&lt;color=1.0 1.0 0.0&gt;Can Be Toggled On/Off&lt;/color&gt;</string>	
+		<string _locid="110046">Activate Paid Labor - Villagers train in 33% less time, but changes their cost to Gold</string>	
+		<string _locid="110047">Improves &lt;color=0.32 0.65 1.0&gt;Berserker&lt;/color&gt;.*&lt;color=0.0 1.0 0.0&gt;+2 Health Regen. Per Second&lt;/color&gt;*&lt;color=0.0 1.0 0.0&gt;Grants Charge&lt;/color&gt;*&lt;color=0.0 1.0 0.0&gt;Grants Snare Immunity&lt;/color&gt;</string>			
 		<!-- Celeste Chat Channel -->
 		<string _locid="160121">PVP</string>
 		<string _locid="160122">DE</string>


### PR DESCRIPTION
**Norse | Berserkers**: Charge behavior changed: 50% Speedboost while charging, from 75%. 8 second charge with 4 second cooldown, from infinite charge. Charge range increased to 20, from 18. Berserker Champion health regeneration decreased to 2, from 4.

 ------
**Global | Caravans and Merchant Transports**: Minor tweaks implemented to improve these units' pathing so that they get stuck less often.

> https://www.dropbox.com/s/czbrwygtazdwdea/New%20Caravan%20Pathing.mp4?dl=0
>
> https://www.dropbox.com/s/mavh5lxdkxqtz2h/New%20Caravan%20Pathing%202.mp4?dl=0