### PR TITLE
PvP Patches #7 and #7.1 (+ some quest string improvements)

### DIFF
--- a/de-DE/de-DE-stringtablex.xml
+++ b/de-DE/de-DE-stringtablex.xml
@@ -11041,7 +11041,7 @@
 		<string _locid="62055">Werkhalle</string>
 		<string _locid="62056">Pe_Craft_Chooser__</string>
 		<string _locid="62057" symbol="cStringCivPersian">PERSER</string>
-		<string _locid="62058">Deaktiviere Lohnarbeit - Dorfbewohner werden um 45% schneller ausgebildet, müssen dann aber mit Gold bezahlt werden</string>
+		<string _locid="62058">Deaktiviere Lohnarbeit - Dorfbewohner werden um 33% schneller ausgebildet, müssen dann aber mit Gold bezahlt werden</string>
 		<string _locid="62059">Kardaka-General Arsham</string>
 		<string _locid="62060">Pferdefürst Siavash</string>
 		<string _locid="62061">Wagenlenker Bahadur</string>
@@ -16631,6 +16631,13 @@
 		<string _locid="110045">Reduziert die Ausbildungsdauer von &lt;color=0.32 0.65 1.0&gt;Dorfbewohnern&lt;/color&gt;, ändert aber ihre Kosten in Gold.*&lt;color=0.0 1.0 0.0&gt;Ausbildungsdauer -33%&lt;/color&gt;*&lt;color=0.0 1.0 0.0&gt;Nahrungskosten -40&lt;/color&gt;*&lt;color=1.0 0.0 0.0&gt;Goldkosten +40&lt;/color&gt;*&lt;color=1.0 1.0 0.0&gt;Kann ein- und ausgeschaltet werden&lt;/color&gt;</string>
 		<string _locid="110046">Deaktiviere Lohnarbeit - Dorfbewohner werden um 33% schneller ausgebildet, müssen dann aber mit Gold bezahlt werden</string>		
 		<string _locid="110047">Verbessert &lt;color=0.32 0.65 1.0&gt;Berserker&lt;/color&gt;.*&lt;color=0.0 1.0 0.0&gt;Lebenspunktregen. pro Sekunde +2&lt;/color&gt;*&lt;color=0.0 1.0 0.0&gt;Bietet Sturmangriff&lt;/color&gt;*&lt;color=0.0 1.0 0.0&gt;Bietet Verlangsamungsimmunität&lt;/color&gt;</string>		
+		<string _locid="110048">Verbessert &lt;color=0.32 0.65 1.0&gt;Magi&lt;/color&gt;.*&lt;color=0.0 1.0 0.0&gt;Bekehrungsgeschwindigkeit +30%&lt;/color&gt;</string>		
+		<string _locid="110049">Verbessert &lt;color=0.32 0.65 1.0&gt;Priester&lt;/color&gt;.*&lt;color=0.0 1.0 0.0&gt;Bekehrungsrate +15%&lt;/color&gt;*&lt;color=0.0 1.0 0.0&gt;Bekehrungsreichweite +10%&lt;/color&gt;*&lt;color=0.0 1.0 0.0&gt;Sichtweite +10%&lt;/color&gt;</string>	
+		<string _locid="110050">Grosspriester</string>		
+		<string _locid="110051">Himmlischer Magus</string>		
+		<string _locid="110052">Druidenältester</string>		
+		<string _locid="110053">Augurenältester</string>
+		<string _locid="110054">Unerbittlicher Kriegshund</string>
 				<!-- Celeste Chat Channel -->
 		<string _locid="160121">PVP</string>
 		<string _locid="160122">DE</string>

--- a/en-US/QuestStringTable.xml
+++ b/en-US/QuestStringTable.xml
@@ -3401,7 +3401,7 @@
 		<string _locid="14004">Face this battle, and discover the traitors.</string>
 		<!-- ALLIANCE TRIBUTE WARS V2-->
 		<string _locid="14005">Legendary: The end of the traitors.</string>
-		<string _locid="14006">Now that we know traitors, we must act quickly. King Agamemnon, Brennos and King Tiestes, will not see you coming. \n \nTake them offhand and beat them on the battlefield. It will not be easy, but we trust you.</string>
+		<string _locid="14006">Now that we know traitors, we must act quickly. King Agamemnon, Brennos and King Tiestes, will not see you coming. \n \nTake them offhand and beat them on the battlefield. It will not be easy, but we have faith in you.</string>
 		<string _locid="14007">Good work, the traitors were defeated and could only escape the battle.</string>
 		<string _locid="14008">If we allow traitors to triumph, the whole Alliance is in danger!</string>
 		<string _locid="14009">Show that you can protect the alliance, and defeat the traitors.</string>
@@ -3412,10 +3412,10 @@
 		<!-- ATHENS CELESTE PDLC SPECIAL EDITION GREEK - La revuelta Griega -->
 		<string _locid="20015">Celeste Special Content: The Greek Revolt</string>
 		<string _locid="20016">New free content available. Travel to Athens and discover new adventures</string>
-		<string _locid="20017">Welcome to Athens, contemplate the splendor of our city. \n \nSo, if you're still here, maybe I need your help. What do you say?</string>
-		<string _locid="20018">Welcome to Athens, contemplate the splendor of our city. \n \nSo, if you're still here, maybe I need your help. What do you say?</string>
+		<string _locid="20017">Welcome to Athens, contemplate the splendor of our city. \n \nSo, if you're still here, I might need your help. What do you say?</string>
+		<string _locid="20018">Welcome to Athens, contemplate the splendor of our city. \n \nSo, if you're still here, I might need your help. What do you say?</string>
 		<string _locid="20019">Speak to the Leader Hoplite in Athens</string>
-		<string _locid="20020">Travel to Athens and talk to Hoplite Leader</string>
+		<string _locid="20020">Travel to Athens and talk to the Hoplite Leader</string>
 		<!-- ATHENS START INCURSION -->
 		<string _locid="20021">Incursion</string>
 		<string _locid="20022">Welcome my friend, we need your help to support our allies and recover some Persian dominated regions, we will only have a minimal group of workers not to attract attention. \n \nIf things turn out well we will have a favorable position and we will be able to assault your Cities. We count on you.</string>
@@ -3424,10 +3424,10 @@
 		<string _locid="20025">Talk to Leader Hoplite and the Dockmaster</string>
 		<!-- INCURSION NAVAL -->
 		<string _locid="20026">Incursion in Quios</string>
-		<string _locid="20027">We have information on some settlements that try to intercept us on the outskirts of their shores. \n \nStay on some small island and defeat them, if you get it our troops will land their coasts and finish with the work.</string>
+		<string _locid="20027">We have information on some settlements that are trying to intercept us on the outskirts of their shores. \n \nStay on some small island and defeat them, if you get it our troops will land on their coasts and complete your work.</string>
 		<string _locid="20028">Good job! I think we will get it!</string>
-		<string _locid="20029">Try not to be discovered and defeat your enemies fast.</string>
-		<string _locid="20030">Build your urban center and eliminate enemies in the area.</string>
+		<string _locid="20029">Try not to be discovered and defeat your enemies quickly.</string>
+		<string _locid="20030">Build your Town Center and eliminate the enemies in the area.</string>
 		<string _locid="20031">Incursion in Clazomene</string>
 		<string _locid="20032">Incursion in Lebedos</string>
 		<string _locid="20033">Incursion in Samos</string>
@@ -3435,22 +3435,22 @@
 		<string _locid="20034">Imperial Collectors</string>
 		<string _locid="20035">Persian Explorers</string>
 		<!-- Objectives -->
-		<string _locid="20036">Town Center Built</string>
+		<string _locid="20036">Town Center built</string>
 		<string _locid="20037">Town Center destroyed</string>
 		<string _locid="20038">Allied Town Center discovered</string>
-		<string _locid="20039">Persian general killed</string>
+		<string _locid="20039">Persian General killed</string>
 		<string _locid="20040">Fortresses destroyed</string>
-		<string _locid="20041">Advanced troop defeated</string>
+		<string _locid="20041">Advanced Troops defeated</string>
 		<string _locid="20042">Completed twenty minutes early</string>	
 		<!-- There i left some spaces for future string or fixes -->
 		<string _locid="20043">Ally submitted</string>
 		<string _locid="20044">Enemies defeated</string>	
-		<string _locid="20045">The ally's Town Center must survive</string>
+		<string _locid="20045">The Ally's Town Center must survive</string>
 		<string _locid="20046">Rebel Ally</string>
-		<string _locid="20047">Wonder Destroyed</string>
+		<string _locid="20047">Wonder destroyed</string>
 		<string _locid="20048">Completed fifteen minutes early</string>
-		<string _locid="20049">Guardians Eliminated in time</string>
-		<string _locid="20050">Built-in Town Center in time</string>
+		<string _locid="20049">Guardians eliminated in time</string>
+		<string _locid="20050">Built Town Center in time</string>
 		<!-- Personality Land -->
 		<string _locid="20051">Eritrea´s Defenders </string>
 		<string _locid="20052">Teos´s Defenders</string>
@@ -3465,15 +3465,15 @@
 		<!-- GLOBAL INCURSION LAND -->
 		<string _locid="20061">New frontiers</string>
 		<string _locid="20062">We need better sea trade routes, if you manage to free these regions from the Persians it would be excellent!</string>
-		<string _locid="20063">Well done boy, now we can expand</string>
+		<string _locid="20063">Well done soldier, now we can expand</string>
 		<string _locid="20064">Remember that in order to expand we need new routes</string>
 		<string _locid="20065">Release the regions</string>
 		
 		<!-- ATHENS ERITREA QUEST -->
 		<string _locid="20066">Eritrea</string>
 		<string _locid="20067">Eritrea is a good starting position for the siege, we must take it quickly and find our allies in the area.</string>
-		<string _locid="20068">Good job, keep it up and our goal will be favorable.</string>
-		<string _locid="20069">Damn Persians, we must end this tyranny.</string>
+		<string _locid="20068">Good job, keep it up and our victory will be complete!</string>
+		<string _locid="20069">Damn Persians, we must end their tyranny!</string>
 		<string _locid="20070">Assault Eritrea and explores the area in search of allies.</string>
 
 		<!-- ATHENS TEOS QUEST -->
@@ -3485,7 +3485,7 @@
 		
 		<!-- ATHENS PRIENE QUEST -->
 		<string _locid="20076">Priene</string>
-		<string _locid="20077">As our troops settle into the northern part of the coast, it would be a good time to rob Priene by surprise.</string>
+		<string _locid="20077">As our troops settle into the northern part of the coast, it would be a good time to assault Priene by surprise.</string>
 		<string _locid="20078">Good job, we must be attentive to what is coming.</string>
 		<string _locid="20079">Be careful, apparently your troops are advanced</string>
 		<string _locid="20080">Assault Priene and eliminates our enemies.</string>
@@ -3494,20 +3494,20 @@
 		<string _locid="20081">Colofon</string>
 		<string _locid="20082">One of our allies has been revealed in Colofon. Go there, assault the region and defend our ally</string>
 		<string _locid="20083">The Gods smile at you friend. Our ally survived and managed to escape to Greece.</string>
-		<string _locid="20084">Our ally is alone and unprotected, go fast in his aid.</string>
+		<string _locid="20084">Our ally is alone and unprotected, he needs your aid swiftly!</string>
 		<string _locid="20085">Assault Colofon and protect our ally.</string>
 		
 		<!-- ATHENS FOCEA QUEST -->
 		<string _locid="20086">Focea</string>
 		<string _locid="20087">Focea is a key region for our mission, if we take it, we can enter the river.</string>
-		<string _locid="20088">Well done, with this victory we have the north coast secured.</string>
+		<string _locid="20088">Well done, with this victory we have the north coast secured!</string>
 		<string _locid="20089">Hurry, we need all the north coast in our favor.</string>
 		<string _locid="20090">Assault Focea and eliminate his troops</string>
 		
 		<!-- ATHENS EFESO QUEST -->
 		<string _locid="20091">Efeso</string>
 		<string _locid="20092">Efeso is a city near Mileto, we must secure it.</string>
-		<string _locid="20093">Well done, with this victory we avoid being flanked</string>
+		<string _locid="20093">Well done, with this victory we have avoided the possibility of being flanked!</string>
 		<string _locid="20094">We must make sure we get this city</string>
 		<string _locid="20095">Assault Efeso and defeat our enemies</string>
 		
@@ -3521,13 +3521,13 @@
 		<!-- ATHENS SARDES QUEST -->
 		<string _locid="20101">Sardes</string>
 		<string _locid="20102">Damn it! Aristagoras attacked solo Mileto and was ambushed, we must give a surprise blow in his city of Sardes so we will divert the attention and Aristagoras could escape.</string>
-		<string _locid="20103">Well done, maybe Aristagoras has a chance</string>
+		<string _locid="20103">Well done, we may have given Aristagoras a second chance!</string>
 		<string _locid="20104">We must defeat the enemy as a place.</string>
 		<string _locid="20105">Assault the city of Sardes</string>
 		
 		<!-- ATHENS MILETO QUEST -->
 		<string _locid="20106">Mileto: Desperate Escape</string>
-		<string _locid="20107">Aristagoras has lost Miletus and needs to escape from the region. Stop the Persian Advanced Troop.</string>
+		<string _locid="20107">Aristagoras has lost Miletus and needs to escape from the region. Stop the Persian Advanced Troops.</string>
 		<string _locid="20108">Well done, Aristagoras lost his city but at least he's still alive.</string>
 		<string _locid="20109">Damn it! This will bring the war to Greece.</string>
 		<string _locid="20110">Defeat the enemy or die with glory.</string>
@@ -3546,7 +3546,7 @@
 		
 		<!-- MESSENGER OF ARISTAGORAS - GLOBAL PERSIAN GENERAL -->
 		<string _locid="20121">Hunting</string>
-		<string _locid="20122">Many people are happy that Athens has been unified! Their lives are peaceful, and they can focus on their homes and families without fear. \n \nUnfortunately, not everyone thrives under peace. The Allied army is bored, and that makes it an easy target. Rebel factions are securing the help of the Generals and become more dangerous than ever. \n \nThese generals have lost their way and will not return. Punish them!</string>
+		<string _locid="20122">Many people are happy that Athens has been unified! Their lives are peaceful, and they can focus on their homes and families without fear. \n \nUnfortunately, not everyone thrives under peace. The Allied army is bored, and that makes it an easy target. Rebel factions are securing the help of the Generals and have become more dangerous than ever. \n \nThese generals have lost their way and will not return. Punish them!</string>
 		<string _locid="20123">We must hunt these Generals</string>
 		
 		<!-- REPEATABLES -->
@@ -3577,7 +3577,7 @@
 		<string _locid="20146">Celeste: Athenian Challenge</string>
 		<string _locid="20147">As a good Athenian warrior you should not have problems in assaulting all regions of the revolt in Elite and Legendary mode. Do you think you can do it?</string>
 		<string _locid="20148">Well done! Your effort was worth it. You have your deserved Prize.</string>
-		<string _locid="20149">What happened? Did you give up for Loser? Is it very difficult for you?</string>		
+		<string _locid="20149">What happened? Are you giving up? Is it too difficult for you?</string>		
 		
 		<!-- SKIRMISH CHAMPION -->
 		<string _locid="20150">1vs1 AI: Skirmish Champion Mode</string>

--- a/en-US/Stringtablex.xml
+++ b/en-US/Stringtablex.xml
@@ -11041,7 +11041,7 @@
 		<string _locid="62055">Crafting Hall</string>
 		<string _locid="62056">Pe_Craft_Chooser__</string>
 		<string _locid="62057" symbol="cStringCivPersian">Persia</string>
-		<string _locid="62058">Activate Paid Labor - Villagers train in 45% less time, but changes their cost to Gold</string>
+		<string _locid="62058">Activate Paid Labor - Villagers train in 33% less time, but changes their cost to Gold</string> <!--edit org 45%-->
 		<string _locid="62059">Kardaka General Arsham</string>
 		<string _locid="62060">Horselord Siavash</string>
 		<string _locid="62061">Charioteer Bahadur</string>
@@ -16584,13 +16584,13 @@
 		<string _locid="100007">Walls of the Architect</string>
 		<string _locid="100008">Walls of the Master Defender</string>
 		<string _locid="100009">Belly Bow of the Master Hunter</string>
-		<string _locid="100010">Divine High Vizier's Robe</string>
+		<string _locid="100010">Divine High Vizier's Robes</string>
 		<string _locid="100011">Arrows of Darkness</string>
-		<string _locid="100012">Tunic of the collector</string>
-		<string _locid="100013">Blessed food of Athens</string>
+		<string _locid="100012">Tunic of the Collector</string>
+		<string _locid="100013">Blessed Food of Athens</string>
 		<string _locid="100014">Divine Heavy Cedar Beams</string>
 		<string _locid="100015">Heavy Destroyer Weave</string>
-		<string _locid="100016">Blessed Dionysus´s Throwing Arm</string>
+		<string _locid="100016">Blessed Dionysus´ Throwing Arm</string>
 		<!-- CELESTE ISLAND -->
 		<string _locid="100017">Celeste Island</string>
 		<string _locid="100018">Under Construction</string>
@@ -16599,7 +16599,7 @@
 		<string _locid="100020">Athens was the main city of ancient Greece in the region called Attica, located southeast of Continental Greece. It is a rocky, triangular peninsula that penetrates the Aegean Sea. \n \nDespite being a mountainous region, it has three important plains. Eleusis, Athens and Marathon. The port of Athens was Piraeus.\n \nIts secure location on the Acropolis and its access to the sea provided a natural advantage over potential rivals such as Thebes and Sparta. \n 	\nThe most widespread legend was that the first king had been Aegeus, whose son-successor Theseus gave splendor to the city of Athens.</string>
 		<string _locid="100021">Leader Hoplite</string>
 		<string _locid="100022">Professor Socrates</string>
-		<string _locid="100023">Hail to stranger, I still need your help, are you interested?</string>
+		<string _locid="100023">Hail to you stranger! I still need your help, are you interested?</string>
 		<string _locid="100024">Messenger of Aristagoras</string>
 		<!-- ATHENS LEGENDARY VENDOR -->
 		<string _locid="100025">At_Cap_BasicStore01__</string>
@@ -16630,7 +16630,14 @@
 		<string _locid="110044">Improves &lt;color=0.32 0.65 1.0&gt;Elephant Archer&lt;/color&gt;.*&lt;color=0.0 1.0 0.0&gt;-1 Population Count&lt;/color&gt;*&lt;color=0.0 1.0 0.0&gt;+50% Melee-Cavalry Armor&lt;/color&gt; </string>		
 		<string _locid="110045">Reduces training time of &lt;color=0.32 0.65 1.0&gt;Villager&lt;/color&gt;, but changes their cost to Gold.*&lt;color=0.0 1.0 0.0&gt;-33% Training Time&lt;/color&gt;*&lt;color=0.0 1.0 0.0&gt;-40 Food Cost&lt;/color&gt;*&lt;color=1.0 0.0 0.0&gt;+40 Gold Cost&lt;/color&gt;*&lt;color=1.0 1.0 0.0&gt;Can Be Toggled On/Off&lt;/color&gt;</string>		
 		<string _locid="110046">Activate Paid Labor - Villagers train in 33% less time, but changes their cost to Gold</string>		
-		<string _locid="110047">Improves &lt;color=0.32 0.65 1.0&gt;Berserker&lt;/color&gt;.*&lt;color=0.0 1.0 0.0&gt;+2 Health Regen. Per Second&lt;/color&gt;*&lt;color=0.0 1.0 0.0&gt;Grants Charge&lt;/color&gt;*&lt;color=0.0 1.0 0.0&gt;Grants Snare Immunity&lt;/color&gt;</string>		
+		<string _locid="110047">Improves &lt;color=0.32 0.65 1.0&gt;Berserker&lt;/color&gt;.*&lt;color=0.0 1.0 0.0&gt;+2 Health Regen. Per Second&lt;/color&gt;*&lt;color=0.0 1.0 0.0&gt;Grants Charge&lt;/color&gt;*&lt;color=0.0 1.0 0.0&gt;Grants Snare Immunity&lt;/color&gt;</string>	
+		<string _locid="110048">Improves &lt;color=0.32 0.65 1.0&gt;Magus&lt;/color&gt;.*&lt;color=0.0 1.0 0.0&gt;+30% Conversion Rate&lt;/color&gt;</string>		
+		<string _locid="110049">Improves &lt;color=0.32 0.65 1.0&gt;Priest&lt;/color&gt;.*&lt;color=0.0 1.0 0.0&gt;+15% Conversion Rate&lt;/color&gt;*&lt;color=0.0 1.0 0.0&gt;+10% Conversion Range&lt;/color&gt;*&lt;color=0.0 1.0 0.0&gt;+10% Line-of-Sight&lt;/color&gt;</string>	
+		<string _locid="110050">Grand Priest</string>		
+		<string _locid="110051">Celestial Magus</string>		
+		<string _locid="110052">Elder Druid</string>		
+		<string _locid="110053">Elder Augur</string>	
+		<string _locid="110054">War Hound</string>		
 		<!-- Celeste Chat Channel -->
 		<string _locid="160121">PVP</string>
 		<string _locid="160122">DE</string>

--- a/es-ES/es-ES-stringtablex.xml
+++ b/es-ES/es-ES-stringtablex.xml
@@ -11041,7 +11041,7 @@
 		<string _locid="62055">Salón de artesanía</string>
 		<string _locid="62056">Pe_Craft_Chooser__</string>
 		<string _locid="62057" symbol="cStringCivPersian">Persia</string>
-		<string _locid="62058">Activar la mano de obra pagada: los aldeanos se forman en un 45% menos de tiempo pero cambia su coste a oro</string>
+		<string _locid="62058">Activar la mano de obra pagada: los aldeanos se forman en un 33% menos de tiempo pero cambia su coste a oro</string>
 		<string _locid="62059">Arsham el General de los kardakas</string>
 		<string _locid="62060">Siavash el Señor de los caballos</string>
 		<string _locid="62061">Bahadur el Auriga</string>
@@ -16631,6 +16631,13 @@
 		<string _locid="110045">Reduce el tiempo de formación de los &lt;color=0.32 0.65 1.0&gt;aldeanos&lt;/color&gt;, pero cambia su coste a oro.*&lt;color=0.0 1.0 0.0&gt;-33% de tiempo de formación&lt;/color&gt;*&lt;color=0.0 1.0 0.0&gt;-40 de coste de comida&lt;/color&gt;*&lt;color=1.0 0.0 0.0&gt;+40 de coste en oro&lt;/color&gt;*&lt;color=1.0 1.0 0.0&gt;Puede activarse y desactivarse&lt;/color&gt;</string>		
 		<string _locid="110046">Activar la mano de obra pagada: los aldeanos se forman en un 45% menos de tiempo pero cambia su coste a oro</string>		
 		<string _locid="110047">Mejora el &lt;color=0.32 0.65 1.0&gt;berserker&lt;/color&gt;.*&lt;color=0.0 1.0 0.0&gt;+2 de regeneración de salud por segundo&lt;/color&gt;*&lt;color=0.0 1.0 0.0&gt;Otorga carga&lt;/color&gt;*&lt;color=0.0 1.0 0.0&gt;Otorga inmunidad contra ralentización&lt;/color&gt;</string>		
+		<string _locid="110048">Mejora el &lt;color=0.32 0.65 1.0&gt;mago&lt;/color&gt;.*&lt;color=0.0 1.0 0.0&gt;+30% de tasa de conversión&lt;/color&gt;</string>		
+		<string _locid="110049">Mejora el &lt;color=0.32 0.65 1.0&gt;sacerdote&lt;/color&gt;.*&lt;color=0.0 1.0 0.0&gt;+15% de velocidad de conversión&lt;/color&gt;*&lt;color=0.0 1.0 0.0&gt;+10% de alcance de conversión&lt;/color&gt;*&lt;color=0.0 1.0 0.0&gt;+10% de campo visual&lt;/color&gt;</string>		
+		<string _locid="110050">Aran Sacerdote</string>		
+		<string _locid="110051">Mago Celestial</string>		
+		<string _locid="110052">Anciano Druid</string>		
+		<string _locid="110053">Anciano Augur</string>	
+		<string _locid="110054">Perro de pelea</string>		
 		<!-- Celeste Chat Channel -->
 		<string _locid="160121">PVP</string>
 		<string _locid="160122">DE</string>

--- a/fr-FR/fr-FR-stringtablex.xml
+++ b/fr-FR/fr-FR-stringtablex.xml
@@ -11041,7 +11041,7 @@
 		<string _locid="62055">Pavillon d&apos;étude</string>
 		<string _locid="62056">Pe_Craft_Chooser__</string>
 		<string _locid="62057" symbol="cStringCivPersian">PERSES</string>
-		<string _locid="62058">Activer Main d&apos;oeuvre payée - Les villageois sont formés en 45 % moins de temps, mais ils coûtent de l&apos;Or.</string>
+		<string _locid="62058">Activer Main d&apos;oeuvre payée - Les villageois sont formés en 33 % moins de temps, mais ils coûtent de l&apos;Or.</string>
 		<string _locid="62059">Général des kardakas Arsham</string>
 		<string _locid="62060">Maître des chevaux Siavash</string>
 		<string _locid="62061">Aurige Bahadur</string>
@@ -16630,7 +16630,14 @@
 		<string _locid="110044">Améliore &lt;color=0.32 0.65 1.0&gt;Archer sur éléphant&lt;/color&gt;.*&lt;color=0.0 1.0 0.0&gt;-1 compte démographique&lt;/color&gt;*&lt;color=0.0 1.0 0.0&gt;Armure d&apos;cavalerie en mêlée +50%&lt;/color&gt;</string>	
 		<string _locid="110045">Réduit le temps de formation des &lt;color=0.32 0.65 1.0&gt;villageois&lt;/color&gt;, mais ils coûtent de l&apos;Or.*&lt;color=0.0 1.0 0.0&gt;-33 % période d&apos;entraînement&lt;/color&gt;*&lt;color=0.0 1.0 0.0&gt;-40 coût de la nourriture&lt;/color&gt;*&lt;color=1.0 0.0 0.0&gt;+40 coût de l&apos;Orlt;/color&gt;*&lt;color=1.0 1.0 0.0&gt;Peut être alterné d&apos;actif à inactif&lt;/color&gt;</string>		
 		<string _locid="110046">Activer Main d&apos;oeuvre payée - Les villageois sont formés en 45 % moins de temps, mais ils coûtent de l&apos;Or.</string>		
-		<string _locid="67579">Améliore les &lt;color=0.32 0.65 1.0&gt;Berserkers&lt;/color&gt;.*&lt;color=0.0 1.0 0.0&gt;Régén. santé par seconde +2&lt;/color&gt;*&lt;color=0.0 1.0 0.0&gt;Octroie Charge&lt;/color&gt;*&lt;color=0.0 1.0 0.0&gt;Octroie Immunité contre les pièges&lt;/color&gt;</string>		
+		<string _locid="110047">Améliore les &lt;color=0.32 0.65 1.0&gt;Berserkers&lt;/color&gt;.*&lt;color=0.0 1.0 0.0&gt;Régén. santé par seconde +2&lt;/color&gt;*&lt;color=0.0 1.0 0.0&gt;Octroie Charge&lt;/color&gt;*&lt;color=0.0 1.0 0.0&gt;Octroie Immunité contre les pièges&lt;/color&gt;</string>	
+		<string _locid="110048">Améliore les &lt;color=0.32 0.65 1.0&gt;mages&lt;/color&gt;.*&lt;color=0.0 1.0 0.0&gt;Taux de conversion +30%&lt;/color&gt;</string>	
+		<string _locid="110049">Améliore les &lt;color=0.32 0.65 1.0&gt;prêtres&lt;/color&gt;.*&lt;color=0.0 1.0 0.0&gt;Taux de conversion +15 %&lt;/color&gt;*&lt;color=0.0 1.0 0.0&gt;Portée de conversion +10 %&lt;/color&gt;*&lt;color=0.0 1.0 0.0&gt;Champ de vision +10 %&lt;/color&gt;</string>		
+		<string _locid="110050">Grand prêtre</string>		
+		<string _locid="110051">Mage celeste</string>		
+		<string _locid="110052">Augure aîné</string>		
+		<string _locid="110053">Druide aîné</string>	
+		<string _locid="110054">Chien de guerre</string>		
 		<!-- Celeste Chat Channel -->
 		<string _locid="160121">PVP</string>
 		<string _locid="160122">DE</string>

--- a/it-IT/it-IT-stringtablex.xml
+++ b/it-IT/it-IT-stringtablex.xml
@@ -11041,7 +11041,7 @@
 		<string _locid="62055">Sala dell&apos;artigianato</string>
 		<string _locid="62056">Pe_Craft_Chooser__</string>
 		<string _locid="62057" symbol="cStringCivPersian">Persia</string>
-		<string _locid="62058">Attiva il lavoro a pagamento - Gli abitanti vengono addestrati a una velocità superiore del 50%, ma costano l&apos;80% in oro</string>
+		<string _locid="62058">Attiva il lavoro a pagamento - Gli abitanti vengono addestrati a una velocità superiore del 33%, ma costano l&apos;80% in oro</string>
 		<string _locid="62059">Generale Arsham dei kardaka</string>
 		<string _locid="62060">Signore dei cavalli Siavash</string>
 		<string _locid="62061">Auriga Bahadur</string>
@@ -16139,7 +16139,14 @@
 		<string _locid="110044">Improves &lt;color=0.32 0.65 1.0&gt;Elephant Archer&lt;/color&gt;.*&lt;color=0.0 1.0 0.0&gt;-1 Population Count&lt;/color&gt;*&lt;color=0.0 1.0 0.0&gt;+50% Melee-Cavalry Armor&lt;/color&gt; </string>				
 		<string _locid="110045">Reduces training time of &lt;color=0.32 0.65 1.0&gt;Villager&lt;/color&gt;, but changes their cost to Gold.*&lt;color=0.0 1.0 0.0&gt;-33% Training Time&lt;/color&gt;*&lt;color=0.0 1.0 0.0&gt;-40 Food Cost&lt;/color&gt;*&lt;color=1.0 0.0 0.0&gt;+40 Gold Cost&lt;/color&gt;*&lt;color=1.0 1.0 0.0&gt;Can Be Toggled On/Off&lt;/color&gt;</string>	
 		<string _locid="110046">Activate Paid Labor - Villagers train in 33% less time, but changes their cost to Gold</string>		
-		<string _locid="110047">Improves &lt;color=0.32 0.65 1.0&gt;Berserker&lt;/color&gt;.*&lt;color=0.0 1.0 0.0&gt;+2 Health Regen. Per Second&lt;/color&gt;*&lt;color=0.0 1.0 0.0&gt;Grants Charge&lt;/color&gt;*&lt;color=0.0 1.0 0.0&gt;Grants Snare Immunity&lt;/color&gt;</string>			
+		<string _locid="110047">Improves &lt;color=0.32 0.65 1.0&gt;Berserker&lt;/color&gt;.*&lt;color=0.0 1.0 0.0&gt;+2 Health Regen. Per Second&lt;/color&gt;*&lt;color=0.0 1.0 0.0&gt;Grants Charge&lt;/color&gt;*&lt;color=0.0 1.0 0.0&gt;Grants Snare Immunity&lt;/color&gt;</string>	
+		<string _locid="110048">Improves &lt;color=0.32 0.65 1.0&gt;Magus&lt;/color&gt;.*&lt;color=0.0 1.0 0.0&gt;+30% Conversion Rate&lt;/color&gt;</string>			
+		<string _locid="110049">Improves &lt;color=0.32 0.65 1.0&gt;Priest&lt;/color&gt;.*&lt;color=0.0 1.0 0.0&gt;+15% Conversion Rate&lt;/color&gt;*&lt;color=0.0 1.0 0.0&gt;+10% Conversion Range&lt;/color&gt;*&lt;color=0.0 1.0 0.0&gt;+10% Line-of-Sight&lt;/color&gt;</string>	
+		<string _locid="110050">Grand Priest</string>		
+		<string _locid="110051">Celestial Magus</string>		
+		<string _locid="110052">Elder Druid</string>		
+		<string _locid="110053">Elder Augur</string>
+		<string _locid="110054">War Hound</string>				
 		<!-- Celeste Chat Channel -->
 		<string _locid="160121">PVP</string>
 		<string _locid="160122">DE</string>

--- a/zh-CHT/zh-CHT-stringtablex.xml
+++ b/zh-CHT/zh-CHT-stringtablex.xml
@@ -11041,7 +11041,7 @@
 		<string _locid="62055">工藝大廳</string>
 		<string _locid="62056">Pe_Craft_Chooser__</string>
 		<string _locid="62057" symbol="cStringCivPersian">波斯</string>
-		<string _locid="62058">啟動有酬勞動——提升 50% 村民訓練速度，但花費80% 黃金</string>
+		<string _locid="62058">啟動有酬勞動——提升 33% 村民訓練速度，但花費80% 黃金</string>
 		<string _locid="62059">波斯重裝步兵將軍 Arsham</string>
 		<string _locid="62060">牧馬王薩瓦什</string>
 		<string _locid="62061">馭夫巴哈杜爾</string>
@@ -16139,7 +16139,14 @@
 		<string _locid="110044">Improves &lt;color=0.32 0.65 1.0&gt;Elephant Archer&lt;/color&gt;.*&lt;color=0.0 1.0 0.0&gt;-1 Population Count&lt;/color&gt;*&lt;color=0.0 1.0 0.0&gt;+50% Melee-Cavalry Armor&lt;/color&gt; </string>				
 		<string _locid="110045">Reduces training time of &lt;color=0.32 0.65 1.0&gt;Villager&lt;/color&gt;, but changes their cost to Gold.*&lt;color=0.0 1.0 0.0&gt;-33% Training Time&lt;/color&gt;*&lt;color=0.0 1.0 0.0&gt;-40 Food Cost&lt;/color&gt;*&lt;color=1.0 0.0 0.0&gt;+40 Gold Cost&lt;/color&gt;*&lt;color=1.0 1.0 0.0&gt;Can Be Toggled On/Off&lt;/color&gt;</string>	
 		<string _locid="110046">Activate Paid Labor - Villagers train in 33% less time, but changes their cost to Gold</string>	
-		<string _locid="110047">Improves &lt;color=0.32 0.65 1.0&gt;Berserker&lt;/color&gt;.*&lt;color=0.0 1.0 0.0&gt;+2 Health Regen. Per Second&lt;/color&gt;*&lt;color=0.0 1.0 0.0&gt;Grants Charge&lt;/color&gt;*&lt;color=0.0 1.0 0.0&gt;Grants Snare Immunity&lt;/color&gt;</string>			
+		<string _locid="110047">Improves &lt;color=0.32 0.65 1.0&gt;Berserker&lt;/color&gt;.*&lt;color=0.0 1.0 0.0&gt;+2 Health Regen. Per Second&lt;/color&gt;*&lt;color=0.0 1.0 0.0&gt;Grants Charge&lt;/color&gt;*&lt;color=0.0 1.0 0.0&gt;Grants Snare Immunity&lt;/color&gt;</string>		
+		<string _locid="110048">Improves &lt;color=0.32 0.65 1.0&gt;Magus&lt;/color&gt;.*&lt;color=0.0 1.0 0.0&gt;+30% Conversion Rate&lt;/color&gt;</string>		
+		<string _locid="110049">Improves &lt;color=0.32 0.65 1.0&gt;Priest&lt;/color&gt;.*&lt;color=0.0 1.0 0.0&gt;+15% Conversion Rate&lt;/color&gt;*&lt;color=0.0 1.0 0.0&gt;+10% Conversion Range&lt;/color&gt;*&lt;color=0.0 1.0 0.0&gt;+10% Line-of-Sight&lt;/color&gt;</string>	
+		<string _locid="110050">Grand Priest</string>		
+		<string _locid="110051">Celestial Magus</string>		
+		<string _locid="110052">Elder Druid</string>		
+		<string _locid="110053">Elder Augur</string>	
+		<string _locid="110054">War Hound</string>				
 		<!-- Celeste Chat Channel -->
 		<string _locid="160121">PVP</string>
 		<string _locid="160122">DE</string>


### PR DESCRIPTION
Greeks:

Battering Ram: Champion upgrade cost reduced to 300g, from 400g. Research time reduced to 30s, from 60s.

Priests: Researching Divine Vision will now also rename the unit to "Grand Priest". Convert rate reduced to 15, from 16.

--------------------
Egyptians:

Siege Tower: Champion upgrade cost reduced to 300g, from 400g. Research time reduced to 30s, from 60s.

--------------------
Persians:

Mounted Archer: DPS reduced to 14, from 16. Bonus Multiplier increased to 2.3x, from 2x.

Paid Labor: Train time reduction reduced to 33%, from 45%

Magus: Researching Without Number now renames the unit to "Celestial Magus". Upgrade cost reduced to 800g, from 1000g. Convert rate reduced to 15, from 16.

Battering Ram: Champion upgrade cost reduced to 300g, from 400g. Research time reduced to 30s, from 60s.

--------------------
Celts:

Champion: Hitpoints increased to 450, from 420.

Gift of Sequana: Now also renames Druids and Augurs to "Elder Druid" and "Elder Augur"

--------------------
Babylonians:

Priest: Researching Code of Hammurabi will now rename the unit to "Grand Priest". Upgrade cost reduced to 1000g, from 1200g. Convert rate reduced to 15, from 16.

--------------------
Norse:

War Dogs: Researching Dog Training will now rename the unit to "War Hound"

Rhapsode: Convert rate reduced to15, from 16.

Seer: Convert rate reduced to 15, from 16.

--------------------
General Changes:

-

=======

[Quest strings files for Athens have received small fixes]